### PR TITLE
Remove peer dep on loopback

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,9 +11,6 @@
   "dependencies": {
     "kafka-node": "~0.1.7"
   },
-  "peerDependencies": {
-      "loopback": "1.x >=1.7.0"
-  },
   "repository": {
     "type": "git",
     "url": "git@github.com:haio/loopback-connector-kafka.git"


### PR DESCRIPTION
The connector does not require anything from loopback and/or juggler.

A version compatibility check should be implemented at runtime if such
need ever arises.

See strongloop/loopback#275 for more details about this change.

/to @haio
